### PR TITLE
Use relative paths for backups and logs

### DIFF
--- a/Make-StopFlag.bat
+++ b/Make-StopFlag.bat
@@ -1,4 +1,3 @@
 @echo off
-cd /d "<path to server folder>"
-
+cd /d "%~dp0"
 echo.> stop.flag

--- a/backup.bat
+++ b/backup.bat
@@ -1,6 +1,15 @@
 @echo off
-set backupDir=C:\Backups\MinecraftBackups
-set worldDir=C:\Users\<user>\Minecraft\<server folder>\world
+
+REM ===== User Configuration =====
+REM Set backupDir to override the default backup save folder.
+REM Example: set "backupDir=D:\Backups\Minecraft"
+set "backupDir="
+REM ===== End User Configuration =====
+
+cd /d "%~dp0"
+
+set "worldDir=%cd%\world"
+if not defined backupDir set "backupDir=%cd%\backups"
 
 :: Make sure backup folder exists
 if not exist "%backupDir%" mkdir "%backupDir%"
@@ -10,10 +19,9 @@ for /f "tokens=2 delims==" %%a in ('wmic os get localdatetime /value') do set da
 set timestamp=%datetime:~0,4%-%datetime:~4,2%-%datetime:~6,2%_%datetime:~8,2%-%datetime:~10,2%-%datetime:~12,2%
 
 :: Create backup zip
-powershell Compress-Archive -Path "%worldDir%" -DestinationPath "%backupDir%\minecraftserver_%timestamp%.zip"
+powershell Compress-Archive -Path "%worldDir%" -DestinationPath "%backupDir%\world_%timestamp%.zip"
 
 :: Keep only last 10 backups, delete older ones
 for /f "skip=10 eol=: delims=" %%F in ('dir /b /o-d "%backupDir%\world_*.zip"') do del "%backupDir%\%%F"
-
 
 echo Backup created: %backupDir%\world_%timestamp%.zip

--- a/minecraft_server_manager.pyw
+++ b/minecraft_server_manager.pyw
@@ -15,6 +15,8 @@ from pathlib import Path
 import os, subprocess, threading, queue, time, json, re, tkinter as tk
 from tkinter import scrolledtext, messagebox, simpledialog
 
+BASE_DIR = Path(__file__).resolve().parent
+
 APP_NAME = "Minecraft Forge Server Manager"
 AUTO_START = True                  # start server automatically when GUI opens
 AUTO_ONLINE_REFRESH_SECS = 30      # how often to auto-run 'list' while running
@@ -23,14 +25,13 @@ AUTO_ONLINE_REFRESH_SECS = 30      # how often to auto-run 'list' while running
 JAVA_PATH = r"C:\\Program Files\\Java\\jdk-21\\bin\\java.exe"  # adjust if needed
 XMS = "2G"    # initial heap
 XMX = "10G"   # max heap
-PLAYER_LOG_PATH = Path(r"D:\\Backups\\MinecraftBackups\\player_activity.log")  # change if desired
 # -----------------------------------------------------------------------------
 
 # Paths anchored to this script location (so repo can move machines/paths)
-BASE_DIR = Path(__file__).resolve().parent
 SERVER_DIR = BASE_DIR
 ASSETS_DIR = BASE_DIR / "assets"
 SPLASH_IMAGE = ASSETS_DIR / "IceFireYinYangTransparent.png"  # optional
+PLAYER_LOG_PATH = BASE_DIR / "playerlogs" / "player_activity.log"
 
 LOG_PATH = SERVER_DIR / "wrapper.log"
 STOP_FLAG = SERVER_DIR / "stop.flag"


### PR DESCRIPTION
## Summary
- Make `backup.bat` and `Make-StopFlag.bat` operate from their own directory and avoid hardcoded paths
- Default backup path to a local `backups` folder with optional user override
- Store player activity logs in a `playerlogs` folder relative to the manager script

## Testing
- `python -m py_compile minecraft_server_manager.pyw`


------
https://chatgpt.com/codex/tasks/task_e_68c58768d254832984caa5fc63b33826