### PR TITLE
Use relative paths in StopServer-And-Hibernate

### DIFF
--- a/StopServer-And-Hibernate.ps1
+++ b/StopServer-And-Hibernate.ps1
@@ -1,5 +1,8 @@
 # Gracefully stop Forge (via stop.flag) then hibernate
-$dir = "C:\Users\saged\Minecraft\IceAndFireServer"
+# Determine the directory that contains this script so paths are relative to
+# the Minecraft server root.  This allows the script to be moved without
+# editing hard-coded paths.
+$dir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $flag = Join-Path $dir "stop.flag"
 $log  = Join-Path $dir "wrapper.log"
 


### PR DESCRIPTION
## Summary
- compute the server root from the script's location instead of hardcoding a path

## Testing
- `pwsh -NoLogo -Command "Get-ExecutionPolicy"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c58f26a20083298596ef7dfaea99f7