### PR TITLE
Fix Windows task creation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 - Future improvements TBD.
+- Fix Windows task creator script by removing unsupported parameter causing errors.
 
 ## [v7e] - 2025-09-12
 ### Added

--- a/Windows_task_creator.ps1
+++ b/Windows_task_creator.ps1
@@ -34,8 +34,8 @@ $stopAction  = New-ScheduledTaskAction -Execute $psExe -Argument "-NoProfile -Ex
 $startPrincipal  = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Highest
 $systemPrincipal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
 
-$setStart = New-ScheduledTaskSettingsSet -WakeToRun:$true -AllowStartIfOnBatteries:$true -DisallowStartIfOnBatteries:$false
-$setStop  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries:$true -DisallowStartIfOnBatteries:$false
+$setStart = New-ScheduledTaskSettingsSet -WakeToRun:$true -AllowStartIfOnBatteries:$true
+$setStop  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries:$true
 
 # --- Remove existing tasks if requested ---
 


### PR DESCRIPTION
## Summary
- Remove unsupported `DisallowStartIfOnBatteries` parameter from Windows scheduled-task settings
- Document fix in changelog

## Testing
- `python -m py_compile minecraft_server_manager.pyw`
- `pwsh -NoLogo -NoProfile -Command "Write-Host Hello"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a48713e883299319b6a06115ed1f