### PR TITLE
Terminate Minecraft manager before hibernation

### DIFF
--- a/StopServer-And-Hibernate.ps1
+++ b/StopServer-And-Hibernate.ps1
@@ -19,5 +19,13 @@ while ((Get-Date) -lt $deadline) {
 }
 if (-not $stopped) { Write-Output "Timeout waiting for server; continuing to power down." }
 
+# Allow the user to see the GUI has stopped before closing the manager
+Start-Sleep -Seconds 10
+
+# Close the minecraft_server_manager.pyw application so it can be relaunched later
+Get-CimInstance Win32_Process |
+    Where-Object { $_.CommandLine -like '*minecraft_server_manager.pyw*' } |
+    ForEach-Object { Invoke-CimMethod -InputObject $_ -MethodName Terminate | Out-Null }
+
 # Hibernate (swap to shutdown in note below if desired)
 shutdown.exe /h


### PR DESCRIPTION
## Summary
- wait 10 seconds to view shutdown
- close minecraft_server_manager.pyw before hibernating

## Testing
- `python -m py_compile minecraft_server_manager.pyw`
- `pwsh -NoLogo -NoProfile -Command "'PowerShell available'"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c5aaada48329bf89c66f22e8c2b6